### PR TITLE
Allow minChunkSize from 100 MB.

### DIFF
--- a/backend/teldrive/teldrive.go
+++ b/backend/teldrive/teldrive.go
@@ -34,7 +34,7 @@ const (
 	timeFormat       = time.RFC3339
 	maxChunkSize     = 2000 * fs.Mebi
 	defaultChunkSize = 500 * fs.Mebi
-	minChunkSize     = 500 * fs.Mebi
+	minChunkSize     = 100 * fs.Mebi
 	authCookieName   = "access_token"
 )
 


### PR DESCRIPTION
As Teldrive allows for a chunk with a minimum size of 100 MB, rclone should have the same.